### PR TITLE
This lib doesn't use unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! `BufOffsetReader` is like `std::io::BufReader`,
 //! but it allows reading at arbitrary positions in the underlying file.
 //!


### PR DESCRIPTION
This lib can use #![forbid(unsafe_code)]